### PR TITLE
Add PDF metadata

### DIFF
--- a/tex/main.tex
+++ b/tex/main.tex
@@ -6,7 +6,6 @@
 \usepackage{graphicx}
 \usepackage{totcount}
 \usepackage{lipsum}
-\usepackage{hyperref}
 \usepackage{fontawesome}
 \usepackage{arrayjobx}
 \usepackage{tikz}

--- a/tex/style.sty
+++ b/tex/style.sty
@@ -3,7 +3,9 @@
 % links
 \usepackage{hyperref}
 \hypersetup {
-    hidelinks
+    hidelinks,
+    pdftitle={UQCS Subject Guide \the\year},
+    pdfauthor={UQ Computing Society},
 }
 % specified by the title page
     \usepackage[svgnames]{xcolor}


### PR DESCRIPTION
With no metadata, the browser tab title is just "main.pdf". This makes it pretty.